### PR TITLE
doc(readme): add links to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ gomacro is an almost complete Go interpreter, implemented in pure Go. It offers 
 an interactive REPL and a scripting mode, and does not require a Go toolchain at runtime
 (except in one very specific case: import of a 3<sup>rd</sup> party package at runtime).
 
-It has two dependencies beyond the Go standard library: github.com/peterh/liner and golang.org/x/sys
+It has two dependencies beyond the Go standard library: [github.com/peterh/liner](https://github.com/peterh/liner) and [golang.org/x/sys](https://godoc.org/golang.org/x/sys).
 
 Gomacro can be used as:
 * a standalone executable with interactive Go REPL, line editing and code completion:


### PR DESCRIPTION
I wanted to look at what they were. So I thought, why not create links while I'm at it?